### PR TITLE
Install binary to /usr/local/bin instead of /usr/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ debug: CFLAGS += -g -DDEBUG
 debug: $(EXE)
 
 install:
-	@install -m 755 $(EXE) /usr/bin
+	@install -m 755 $(EXE) /usr/local/bin
 	@install -m 644 hed.1 /usr/local/share/man/man1
 
 $(EXE): $(OBJ)


### PR DESCRIPTION
Installing to `/usr/bin` increases the risk of conflict with system binaries, so before building, I edited the Makefile to install to `/usr/local/bin` instead.